### PR TITLE
TextInputBox에 type, unit 옵션 추가

### DIFF
--- a/components/Inputs/index.tsx
+++ b/components/Inputs/index.tsx
@@ -18,6 +18,8 @@ interface TextInputBoxProps extends InputProps {
   labelName?: string | null;
   placeholder?: string;
   option?: string;
+  unit?: string;
+  type?: string;
 }
 
 function TextInputComponent({
@@ -49,7 +51,9 @@ export function TextInputBoxComponent({
   maxLength,
   labelName,
   placeholder,
-  option
+  option,
+  unit,
+  type
 }: TextInputBoxProps) {
   const [value, setValue] = useState<string>('');
   const handleChange = useCallback((e) => {
@@ -62,7 +66,7 @@ export function TextInputBoxComponent({
     <Styled.Box width={width}>
       {labelName && <Styled.Label htmlFor={id}>{labelName}</Styled.Label>}
       <Styled.InputBox
-        type={option === 'password' ? 'password' : 'text'}
+        type={type ?? (option === 'password' ? 'password' : 'text')}
         id={id}
         maxLength={maxLength}
         value={value}
@@ -89,6 +93,9 @@ export function TextInputBoxComponent({
                 <Check viewBox="0 0 28 28" />
               </Styled.CheckWrapper>
             );
+          case 'unit': {
+            return <Styled.Unit>{unit}</Styled.Unit>;
+          }
           default:
             return null;
         }
@@ -108,7 +115,9 @@ TextInputBoxComponent.defaultProps = {
   maxLength: '',
   labelName: null,
   placeholder: '',
-  option: 'none'
+  option: 'none',
+  unit: '',
+  type: 'text'
 };
 
 export const TextInput = React.memo(TextInputComponent);

--- a/components/Inputs/styled.ts
+++ b/components/Inputs/styled.ts
@@ -33,6 +33,10 @@ export const InputBox = styled.input<inputProps>`
   &:focus {
     border: 1px solid ${COLOR.accentColor};
   }
+  &:focus + div {
+    border: 1px solid ${COLOR.accentColor};
+    background-color: ${COLOR.accentColor};
+  }
 `;
 
 export const Label = styled.label`
@@ -53,4 +57,19 @@ export const CheckWrapper = styled(ImageWrapper)`
   position: absolute;
   bottom: 1.3rem;
   right: 1.6rem;
+`;
+
+export const Unit = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 5.4rem;
+  height: 5.4rem;
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+  background-color: ${COLOR.greyC4};
+  color: ${COLOR.white};
 `;

--- a/pages/component-test/index.tsx
+++ b/pages/component-test/index.tsx
@@ -1,0 +1,23 @@
+import { TextInputBox } from 'components/Inputs';
+import { GetStaticProps } from 'next';
+
+function ComponentTest() {
+  return (
+    <>
+      <TextInputBox labelName="판매가" option="unit" unit="원" />
+      <TextInputBox />
+    </>
+  );
+}
+
+export const getStaticProps: GetStaticProps = () => {
+  return {
+    props: {
+      gnb: {
+        active: false
+      }
+    }
+  };
+};
+
+export default ComponentTest;


### PR DESCRIPTION
# 🔀 PR

## 종류
- [X] 기능 추가
- [X] 기능 및 버그 수정
- [ ] 리팩토링
- [ ] 세팅
- [ ] CI/CD

## 설명
- Input 태그의 type을 동적으로 설정할 수 있도록 type props 추가
- 돈이나 상품의 단위를 나타낼 수 있도록 unit props 추가
