### PR TITLE
API 요청시 ReferenceError가 발생하는 버그 수정

### DIFF
--- a/lib/mongoose/models/CouponType.ts
+++ b/lib/mongoose/models/CouponType.ts
@@ -13,7 +13,10 @@ export const CouponTypeSchema = new Schema(
       type: [
         {
           type: String,
-          enum: [CATEGORY_ENUM, '카테고리가 유효하지 않습니다.']
+          enum: {
+            values: CATEGORY_ENUM,
+            message: '카테고리가 유효하지 않습니다.'
+          }
         }
       ]
     },

--- a/lib/mongoose/models/Order.ts
+++ b/lib/mongoose/models/Order.ts
@@ -33,7 +33,10 @@ export const OrderSchema = new Schema(
     },
     courier: {
       type: String,
-      enum: [COURIER_ENUM, '택배사명이 유효하지 않습니다.']
+      enum: {
+        values: COURIER_ENUM,
+        message: '택배사명이 유효하지 않습니다.'
+      }
     },
     invoice: {
       type: Number

--- a/lib/mongoose/models/Product.ts
+++ b/lib/mongoose/models/Product.ts
@@ -33,7 +33,10 @@ export const ProductSchema = new Schema(
       type: [
         {
           type: String,
-          enum: [CATEGORY_ENUM, '카테고리가 유효하지 않습니다.']
+          enum: {
+            values: CATEGORY_ENUM,
+            message: '카테고리가 유효하지 않습니다.'
+          }
         }
       ],
       required: [true, '카테고리를 입력하세요.']


### PR DESCRIPTION
# 🔀 PR

## 종류
- [ ] 기능 추가
- [X] 기능 및 버그 수정
- [ ] 리팩토링
- [ ] 세팅
- [ ] CI/CD

## 설명
- API 요청시 `ReferenceError: Cannot access '__WEBPACK_DEFAULT_EXPORT__' before initialization` 에러 발생
- mongoose Schema에서 enum의 에러 처리를 Object Syntax로 변경하여 해결하였습니다.

## 이슈 번호
- #71 
