### PR TITLE
unit이 있는 Input에 숫자 포맷팅 추가

### DIFF
--- a/src/components/Inputs/index.tsx
+++ b/src/components/Inputs/index.tsx
@@ -58,6 +58,10 @@ export function TextInputBoxComponent({
   type
 }: TextInputBoxProps) {
   const [value, setValue] = useState<string>('');
+  const format = useCallback((val: string) => {
+    const numbers = val.replace(/[^0-9]/g, '');
+    return numbers ? Number(numbers).toLocaleString('ko-kr') : '';
+  }, []);
   const handleChange = useCallback((e) => {
     setValue(e.target.value);
   }, []);
@@ -72,7 +76,7 @@ export function TextInputBoxComponent({
         type={option === 'password' ? 'password' : type}
         id={id}
         maxLength={maxLength}
-        value={value}
+        value={option === 'unit' ? format(value) : value}
         placeholder={placeholder}
         hasOption={option !== 'none'}
         onChange={handleChange}


### PR DESCRIPTION
# 🔀 PR

## 종류
- [X] 기능 추가
- [ ] 기능 및 버그 수정
- [ ] 리팩토링
- [ ] 세팅
- [ ] CI/CD

## 설명
- option이 unit인 Input 컴포넌트의 value를 세 자리 단위로 콤마로 끊는 포맷팅하도록 변경(숫자 외 다른 문자열 필터)