### PR TITLE
아이디 중복 검사 API 추가

### DIFF
--- a/src/pages/api-test/utils.ts
+++ b/src/pages/api-test/utils.ts
@@ -60,6 +60,16 @@ export const apiList = [
             query: [['email', '이메일']]
           }
         ]
+      },
+      {
+        url: '/unique',
+        api: [
+          {
+            method: 'get',
+            button: '아이디 중복 확인',
+            query: [['id', '아이디']]
+          }
+        ]
       }
     ]
   },

--- a/src/pages/api/user/id/index.ts
+++ b/src/pages/api/user/id/index.ts
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { success } from 'lib/mongoose/response';
+import { fail, success } from 'lib/mongoose/response';
 import createHandler from 'lib/mongoose/createHandler';
 
 const handler = createHandler();
@@ -10,7 +10,11 @@ handler.get(async (req, res) => {
     query: { email }
   } = req;
   const user = await User.findOne({ email }, 'userId -_id');
-  success(res, user);
+  if (user) {
+    success(res, user);
+  } else {
+    fail(res);
+  }
 });
 
 export default handler;

--- a/src/pages/api/user/unique/index.ts
+++ b/src/pages/api/user/unique/index.ts
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+import { success } from 'lib/mongoose/response';
+import createHandler from 'lib/mongoose/createHandler';
+
+const handler = createHandler();
+const { User } = mongoose.models;
+
+handler.get(async (req, res) => {
+  const {
+    query: { id }
+  } = req;
+  const isUnique = !(await User.exists({ userId: id }));
+  success(res, { isUnique });
+});
+
+export default handler;


### PR DESCRIPTION
# 🔀 PR

## 종류
- [X] 기능 추가
- [X] 기능 및 버그 수정
- [ ] 리팩토링
- [ ] 세팅
- [ ] CI/CD

## 설명
- 아이디 중복 검사 API 추가
- 아이디 찾기에 실패했을 때 success를 false로 응답하도록 변경

## 이슈 번호
- #81 
