### PR TITLE
상품의 리뷰와 문의를 조회하는 API 분리

### DIFF
--- a/lib/mongoose/constants.ts
+++ b/lib/mongoose/constants.ts
@@ -26,10 +26,7 @@ export const ORDER_STATUS_ENUM = [
   '발송대기',
   '배송중',
   '배송완료',
-  '구매확정',
-  '취소요청',
-  '반품요청',
-  '교환요청'
+  '구매확정'
 ];
 export const COURIER_ENUM = [
   'CJ대한통운',

--- a/src/pages/api-test/utils.ts
+++ b/src/pages/api-test/utils.ts
@@ -245,6 +245,36 @@ export const apiList = [
         button: '상품ID로 특정 상품 정보 삭제하기',
         param: ['상품ID', 'id']
       }
+    ],
+    nested: [
+      {
+        url: '/review',
+        api: [
+          {
+            method: 'get',
+            button: '상품ID로 상품에 대한 리뷰 정보 조회하기',
+            param: ['상품ID', 'id'],
+            query: [
+              ['page', '페이지'],
+              ['limit', '페이지당 목록 개수']
+            ]
+          }
+        ]
+      },
+      {
+        url: '/inquiry',
+        api: [
+          {
+            method: 'get',
+            button: '상품ID로 상품에 대한 문의 정보 조회하기',
+            param: ['상품ID', 'id'],
+            query: [
+              ['page', '페이지'],
+              ['limit', '페이지당 목록 개수']
+            ]
+          }
+        ]
+      }
     ]
   },
   {

--- a/src/pages/api/product/[id].ts
+++ b/src/pages/api/product/[id].ts
@@ -7,40 +7,9 @@ const { Product } = mongoose.models;
 
 handler.get(async (req, res) => {
   const {
-    query: { id },
-    locals: {
-      pagination: { skip, limit }
-    }
+    query: { id }
   } = req;
-  const product = await Product.findById(id, '-updatedAt')
-    .populate({
-      path: 'reviews',
-      populate: {
-        path: 'user',
-        model: 'User',
-        select: 'nickname image'
-      },
-      select: '-product -updatedAt',
-      options: {
-        sort: { createdAt: -1 },
-        skip,
-        limit
-      }
-    })
-    .populate({
-      path: 'inquiries',
-      populate: {
-        path: 'user',
-        model: 'User',
-        select: 'nickname image'
-      },
-      select: '-product -updatedAt',
-      options: {
-        sort: { createdAt: -1 },
-        skip,
-        limit
-      }
-    })
+  const product = await Product.findById(id, '-reviews -inquiries -updatedAt')
     .lean()
     .exec();
   send(res, product);
@@ -74,7 +43,7 @@ handler.put(async (req, res) => {
       categories,
       description
     },
-    { new: true, select: '-updatedAt' }
+    { new: true, select: '-reviews -inquiries -updatedAt' }
   )
     .lean()
     .exec();
@@ -85,7 +54,9 @@ handler.delete(async (req, res) => {
   const {
     query: { id }
   } = req;
-  const product = await Product.findByIdAndDelete(id, { select: '-updatedAt' })
+  const product = await Product.findByIdAndDelete(id, {
+    select: '-reviews -inquiries -updatedAt'
+  })
     .lean()
     .exec();
   send(res, product);

--- a/src/pages/api/product/inquiry/[id].ts
+++ b/src/pages/api/product/inquiry/[id].ts
@@ -1,0 +1,32 @@
+import mongoose from 'mongoose';
+import { send } from 'lib/mongoose/utils/response';
+import createHandler from 'lib/mongoose/utils/createHandler';
+import pagination from 'lib/mongoose/middlewares/pagination';
+
+const handler = createHandler(pagination);
+const { Product } = mongoose.models;
+
+handler.get(async (req, res) => {
+  const {
+    query: { id },
+    locals: {
+      pagination: { skip, limit }
+    }
+  } = req;
+  const product = await Product.findById(id)
+    .populate({
+      path: 'inquiries',
+      populate: {
+        path: 'user',
+        model: 'User',
+        select: 'nickname image'
+      },
+      select: '-updatedAt',
+      options: { skip, limit, sort: { createdAt: -1 } }
+    })
+    .lean()
+    .exec();
+  send(res, product.inquiries);
+});
+
+export default handler;

--- a/src/pages/api/product/review/[id].ts
+++ b/src/pages/api/product/review/[id].ts
@@ -1,0 +1,32 @@
+import mongoose from 'mongoose';
+import { send } from 'lib/mongoose/utils/response';
+import createHandler from 'lib/mongoose/utils/createHandler';
+import pagination from 'lib/mongoose/middlewares/pagination';
+
+const handler = createHandler(pagination);
+const { Product } = mongoose.models;
+
+handler.get(async (req, res) => {
+  const {
+    query: { id },
+    locals: {
+      pagination: { skip, limit }
+    }
+  } = req;
+  const product = await Product.findById(id)
+    .populate({
+      path: 'reviews',
+      populate: {
+        path: 'user',
+        model: 'User',
+        select: 'nickname image'
+      },
+      select: '-updatedAt',
+      options: { skip, limit, sort: { createdAt: -1 } }
+    })
+    .lean()
+    .exec();
+  send(res, product.reviews);
+});
+
+export default handler;


### PR DESCRIPTION
# 🔀 PR

## 종류
- [X] 기능 추가
- [X] 기능 및 버그 수정
- [ ] 리팩토링
- [ ] 세팅
- [ ] CI/CD

## 설명
- product/:id 대신 product/review/:id와 product/inquiry/:id로 특정 상품의 리뷰와 문의를 조회하도록 API 분리
(최초 상품페이지 로드시에 한꺼번에 불러오면 좋지만, 리뷰나 문의의 페이지네이션을 할 때마다 상품 정보를 중복으로 불러오므로 분리하였습니다.)

## 이슈 번호
- #108 
